### PR TITLE
Ignore file `compile` that is generated by autogen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ m4/lt~obsolete.m4
 missing
 stamp-h1
 aac-enc
+compile


### PR DESCRIPTION
`./autogen.sh` generates a file named "compile", and this should probably be ignored.
