### PR TITLE
Fix the preprocessor statements controlling the use of mips{32,64}r1 instructions

### DIFF
--- a/libFDK/include/mips/cplx_mul.h
+++ b/libFDK/include/mips/cplx_mul.h
@@ -89,7 +89,7 @@ amm-info@iis.fraunhofer.de
 ******************************************************************************/
 
 
-#if defined(__GNUC__) && defined(__mips__) && __mips_isa_rev < 6
+#if defined(__GNUC__) && defined(__mips_isa_rev) && __mips_isa_rev < 6
 
 
 //#define FUNCTION_cplxMultDiv2_32x16


### PR DESCRIPTION
Only enable code using mips32/mips64 instructions if the compiler is targetting
this ISA. (integer madd and msub instructions aren't available in the
``canonical'' mips ISAs)

This patch was originally created and committed by Miod Vallat to [OpenBSD](http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/audio/fdk-aac/patches/patch-libFDK_include_mips_cplx_mul_h?rev=1.1&content-type=text/x-cvsweb-markup).