### PR TITLE
Make sure there are enough bits when reading ADTS header.

### DIFF
--- a/libMpegTPDec/src/tpdec_adts.cpp
+++ b/libMpegTPDec/src/tpdec_adts.cpp
@@ -185,6 +185,9 @@ TRANSPORTDEC_ERROR adtsRead_DecodeHeader(
 #endif
 
   valBits = FDKgetValidBits(hBs);
+  if (valBits < ADTS_HEADERLENGTH) {
+    return TRANSPORTDEC_NOT_ENOUGH_BITS;
+  }
 
   /* adts_fixed_header */
   bs.mpeg_id           = FDKreadBits(hBs, Adts_Length_Id);


### PR DESCRIPTION
I was running into a problem with streaming ADTS AAC files where adtsRead_DecodeHeader() was returning TRANSPORTDEC_UNSUPPORTED_FORMAT while parsing the stream. I tracked the issue down to the code trying to read the ADTS header when there weren't enough valid bits in the input buffer.

This change fixed the problem for me.