### PR TITLE
Fix SBR multichannel noise

### DIFF
--- a/libSBRdec/src/sbrdecoder.cpp
+++ b/libSBRdec/src/sbrdecoder.cpp
@@ -1444,7 +1444,7 @@ sbrDecoder_DecodeElement (
     self->flags |= (applyPs) ? SBRDEC_PS_DECODED : 0;
   }
 
-  if (channelMapping[0] == 255 || channelMapping[1] == 255)
+  if (channelMapping[0] == 255 || ((*numOutChannels == 2) && channelMapping[1] == 255))
     return SBRDEC_UNSUPPORTED_CONFIG;
   if (!pSbrChannel[0]->SbrDec.LppTrans.pSettings)
     return SBRDEC_UNSUPPORTED_CONFIG;


### PR DESCRIPTION
for 5.1 ch, the channel elements are as follows: SCE - CPE - CPE - LFE
and the channel-mapping table for 5.1 ch is :
{ 2, 0, 1, 4, 5, 3,255,255}, /* 5.1ch */

For the last LFE channel, sbr decoder returns error, SBRDEC_UNSUPPORTED_CONFIG;