### PR TITLE
fix compilation with mips16

### DIFF
--- a/libFDK/include/mips/abs_mips.h
+++ b/libFDK/include/mips/abs_mips.h
@@ -107,7 +107,7 @@ amm-info@iis.fraunhofer.de
 
 #if defined(__GNUC__) && defined(__mips__)
 
-#if defined(__mips_dsp)
+#if defined(__mips_dsp) && !defined(__mips16)
 #define FUNCTION_fixabs_D
 #define FUNCTION_fixabs_I
 #define FUNCTION_fixabs_S

--- a/libFDK/include/mips/scale_mips.h
+++ b/libFDK/include/mips/scale_mips.h
@@ -103,7 +103,7 @@ amm-info@iis.fraunhofer.de
 #ifndef SCALE_MIPS_H
 #define SCALE_MIPS_H
 
-#if defined(__mips_dsp)
+#if defined(__mips_dsp) && !defined(__mips16)
 
 /*!
  *

--- a/libFDK/include/scramble.h
+++ b/libFDK/include/scramble.h
@@ -108,7 +108,7 @@ amm-info@iis.fraunhofer.de
 #if defined(__arm__)
 #include "arm/scramble_arm.h"
 
-#elif defined(__mips__) && defined(__mips_dsp)
+#elif defined(__mips__) && defined(__mips_dsp) && !defined(__mips16)
 #include "mips/scramble_mips.h"
 
 #endif

--- a/libFDK/src/fft_rad2.cpp
+++ b/libFDK/src/fft_rad2.cpp
@@ -109,7 +109,7 @@ amm-info@iis.fraunhofer.de
 #if defined(__arm__)
 #include "arm/fft_rad2_arm.cpp"
 
-#elif defined(__GNUC__) && defined(__mips__) && defined(__mips_dsp)
+#elif defined(__GNUC__) && defined(__mips__) && defined(__mips_dsp) && !defined(__mips16)
 #include "mips/fft_rad2_mips.cpp"
 
 #endif

--- a/libFDK/src/mips/scale_mips.cpp
+++ b/libFDK/src/mips/scale_mips.cpp
@@ -100,7 +100,7 @@ amm-info@iis.fraunhofer.de
 
 *******************************************************************************/
 
-#if defined(__mips_dsp)
+#if defined(__mips_dsp) && !defined(__mips16)
 
 #ifndef FUNCTION_getScalefactor_DBL
 #define FUNCTION_getScalefactor_DBL


### PR DESCRIPTION
Some users wrongly pass both -mips16 and -mdsp when compiling on MIPS
platforms. Handle such a case.

Signed-off-by: Rosen Penev <rosenp@gmail.com>