### PR TITLE
Add build support for s390x

### DIFF
--- a/libFDK/include/FDK_archdef.h
+++ b/libFDK/include/FDK_archdef.h
@@ -232,6 +232,14 @@ amm-info@iis.fraunhofer.de
 #elif defined(__powerpc__)
 #define ARCH_PREFER_MULT_32x32
 
+#elif defined(__s390x__)
+#define ARCH_PREFER_MULT_32x32
+#define ARCH_PREFER_MULT_32x16
+#define SINETABLE_16BIT
+#define POW2COEFF_16BIT
+#define LDCOEFF_16BIT
+#define WINDOWTABLE_16BIT
+
 #else
 #warning >>>> Please set architecture characterization defines for your platform (FDK_HIGH_PERFORMANCE)! <<<<
 


### PR DESCRIPTION
Debian has been carrying this patch for years so I'm forwarding here.

Successful build log at https://buildd.debian.org/status/package.php?p=fdk-aac